### PR TITLE
Allow extra params to be passed through to Casper

### DIFF
--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -18,7 +18,13 @@ module.exports = function (grunt) {
         // Get spawn function for the CasperJS process creation
         spawn = require('child_process').spawn,
         // Create array that will contain all the parameters for CasperJS
-        command = [];
+        command = ['test'];
+
+    // Get filepaths from 'src' and sorts alphabetically
+    var filepaths = grunt.file.expandFiles(this.file.src).sort();
+
+    // add CasperJS parameter array to filepath array
+    command.push(filepaths);
 
     // Get CasperJS test options and add them to command array
     if (options.xunit) {
@@ -45,20 +51,10 @@ module.exports = function (grunt) {
     if (options.params) {
       var params = options.params;
       for (var p in params) {
-        if (p !== 'unNamed') {
-          command.push('--' + p + '=' + params[p]);
-        } else {
-          command = command.concat(params[p]);
-        }
+        command.push('--' + p + '=' + params[p]);
       }
     }
 
-    // Get filepaths from 'src' and sorts alphabetically
-    var filepaths = grunt.file.expandFiles(this.file.src).sort();
-
-    // add CasperJS parameter array to filepath array
-    command = filepaths.concat(command);
- 
     // Function to wrap grunt log output at 80 characters
     var lastSpace;
     function wrap(str) {

--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -18,7 +18,8 @@ module.exports = function (grunt) {
         // Get spawn function for the CasperJS process creation
         spawn = require('child_process').spawn,
         // Create array that will contain all the parameters for CasperJS
-        command = ['test'];
+        command = ['test'],
+        len;
 
     // Get CasperJS test options and add them to command array
     if (options.xunit) {
@@ -42,12 +43,15 @@ module.exports = function (grunt) {
     if (options.failFast) {
       command.push('--fail-fast');
     }
+    if (options.args) {
+      command = command.concat(formatArgs(options.args));
+    }
 
     // Get filepaths from 'src' and sorts alphabetically
     var filepaths = grunt.file.expandFiles(this.file.src).sort();
 
-    // Get filepaths from 'src' array and add them to CasperJS parameter array
-    command = command.concat(grunt.file.expandFiles(this.file.src).sort());
+    // add CasperJS parameter array to filepath array
+    command = filepaths.concat(command);
  
     // Function to wrap grunt log output at 80 characters
     var lastSpace;
@@ -63,6 +67,32 @@ module.exports = function (grunt) {
       grunt.log.write(str.substr(0, lastSpace) + '\n');
       // Calls itself with the rest of the string that was no logged
       wrap(str.substr(lastSpace + 1));
+    }
+
+    // Checks if something is an array
+    function isArr (arr) {
+      return Object.prototype.toString.call(arr) === '[object Array]';
+    }
+
+    // Formats named or anonymous arguments
+    function formatArgs(params){
+      var len, 
+          rtn = [];
+      
+      if (isArr(options.args)) {
+        // Array of anonymous arguments
+        len = params.length;
+        for (var i = 0; i < len; i++) {
+          rtn.push(params[i]);
+        }
+      } else {
+        // Object containing named arguments
+        for (var p in params) {
+          rtn.push('--' + p + '=' + params[p]);
+        }
+      }
+
+      return rtn;
     }
 
     // Additional Options

--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
         // Get spawn function for the CasperJS process creation
         spawn = require('child_process').spawn,
         // Create array that will contain all the parameters for CasperJS
-        command = ['test'],
+        command = [],
         len;
 
     // Get CasperJS test options and add them to command array

--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -18,8 +18,7 @@ module.exports = function (grunt) {
         // Get spawn function for the CasperJS process creation
         spawn = require('child_process').spawn,
         // Create array that will contain all the parameters for CasperJS
-        command = [],
-        params;
+        command = [];
 
     // Get CasperJS test options and add them to command array
     if (options.xunit) {
@@ -44,7 +43,7 @@ module.exports = function (grunt) {
       command.push('--fail-fast');
     }
     if (options.params) {
-      params = options.params;
+      var params = options.params;
       for (var p in params) {
         if (p !== 'unNamed') {
           command.push('--' + p + '=' + params[p]);

--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -19,7 +19,7 @@ module.exports = function (grunt) {
         spawn = require('child_process').spawn,
         // Create array that will contain all the parameters for CasperJS
         command = [],
-        len;
+        params;
 
     // Get CasperJS test options and add them to command array
     if (options.xunit) {
@@ -43,10 +43,14 @@ module.exports = function (grunt) {
     if (options.failFast) {
       command.push('--fail-fast');
     }
-    if (options.args) {
-      len = options.args.length;
-      for (var i = 0; i < len; i++) {
-        command.push(options.args[i]);
+    if (options.params) {
+      params = options.params;
+      for (var p in params) {
+        if (p !== 'unNamed') {
+          command.push('--' + p + '=' + params[p]);
+        } else {
+          command = command.concat(params[p]);
+        }
       }
     }
 

--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -18,8 +18,7 @@ module.exports = function (grunt) {
         // Get spawn function for the CasperJS process creation
         spawn = require('child_process').spawn,
         // Create array that will contain all the parameters for CasperJS
-        command = [],
-        len;
+        command = [];
 
     // Get CasperJS test options and add them to command array
     if (options.xunit) {

--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -18,7 +18,8 @@ module.exports = function (grunt) {
         // Get spawn function for the CasperJS process creation
         spawn = require('child_process').spawn,
         // Create array that will contain all the parameters for CasperJS
-        command = [];
+        command = [],
+        len;
 
     // Get CasperJS test options and add them to command array
     if (options.xunit) {
@@ -43,7 +44,10 @@ module.exports = function (grunt) {
       command.push('--fail-fast');
     }
     if (options.args) {
-      command = command.concat(formatArgs(options.args));
+      len = options.args.length;
+      for (var i = 0; i < len; i++) {
+        command.push(options.args[i]);
+      }
     }
 
     // Get filepaths from 'src' and sorts alphabetically
@@ -66,32 +70,6 @@ module.exports = function (grunt) {
       grunt.log.write(str.substr(0, lastSpace) + '\n');
       // Calls itself with the rest of the string that was no logged
       wrap(str.substr(lastSpace + 1));
-    }
-
-    // Checks if something is an array
-    function isArr (arr) {
-      return Object.prototype.toString.call(arr) === '[object Array]';
-    }
-
-    // Formats named or anonymous arguments
-    function formatArgs(params){
-      var len, 
-          rtn = [];
-      
-      if (isArr(options.args)) {
-        // Array of anonymous arguments
-        len = params.length;
-        for (var i = 0; i < len; i++) {
-          rtn.push(params[i]);
-        }
-      } else {
-        // Object containing named arguments
-        for (var p in params) {
-          rtn.push('--' + p + '=' + params[p]);
-        }
-      }
-
-      return rtn;
     }
 
     // Additional Options


### PR DESCRIPTION
I made a quick addition to allow extra params to be passed through to Casper.  In my case I'm using it to pass through a port number, but you could use it for a bunch of stuff I guess.  There's some more details on the cli options here:  http://casperjs.org/cli.html  I hope it's helpful!
