### PR TITLE
Updated to the Grunt options API

### DIFF
--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
   // Create MultiTask 'ghost'
   grunt.registerMultiTask('ghost', 'Runs CasperJS Tests.', function () {
     // Get options object
-    var options = this.data.options,
+    var options = this.options(),
         // Tells Grunt that this asynchronous and that it is finished when
         // "done()" is called
         done = this.async(),


### PR DESCRIPTION
This way you can configure multiple targets for `grunt-ghost` as follows without duplicating the options block:

``` js
ghost: {
  options: { /* ... */ },
  target1: { /* ... */ },
  target2: { /* ... */ },
}
```
