### PR TITLE
Grunt-style configuration format for files

### DIFF
--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -16,7 +16,10 @@ module.exports = function (grunt) {
         // "done()" is called
         done = this.async(),
         // Get filepaths from 'src' and sorts alphabetically
-        filepaths = this.data.filesSrc.sort(),
+        filepaths = [].concat(
+          (this.data.filesSrc || []),
+          (this.files || []).map(function (file) { return file.src; })
+        ).sort(),
         // Create array that will contain all the parameters for CasperJS
         command = ['test'].concat(filepaths);
 


### PR DESCRIPTION
This patch is backwards compatible with the `filesSrc` property. It adds support for the files globbing/expanding/etc as described in [Configuring-tasks](https://github.com/gruntjs/grunt/wiki/Configuring-tasks).

``` javascript
ghost: {
  test: {
    files: [{
      src: ['tests/ghost/**/*_test.js']
    }]
  },
}
```
