### PR TITLE
includes option not able to take more than 2 files?

### DIFF
--- a/tasks/ghost.js
+++ b/tasks/ghost.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
     // Prints command sent to CasperJS
     if (options.printCommand) {
       wrap('\u001b[1m\u001b[4mCommand:\u001b[0m casperjs ' +
-           command.join(' ') + ' \n');
+           command.join(' '));
     }
 
     // Prints filepaths sent to CasperJS in alternating colors


### PR DESCRIPTION
I've been working on setting up a basic testing framework for our project. Yesterday I stumbled upon an issue where grunt will fail when including more than 2 files.

My configuration for grunt-ghost looks like this:

```
ghost: {
    dist: {
        filesSrc: ['node_modules/oae-core/*/tests/*.js', 'tests/casperjs/suites/'],
        options: {
            includes: [
                'tests/casperjs/util/include/content.js',
                'tests/casperjs/util/include/users.js',
                'tests/casperjs/util/include/util.js'
            ],
            failFast: false,
            printCommand: true
        }
    }
}
```

If I construct the same command manually and execute it as `casperjs test ...` it works just fine.
